### PR TITLE
Parameterize route correction search depth to avoid infinite loops

### DIFF
--- a/navsim/planning/metric_caching/caching.py
+++ b/navsim/planning/metric_caching/caching.py
@@ -91,6 +91,8 @@ def cache_scenarios(args: List[Dict[str, Union[List[str], DictConfig]]]) -> List
             cache_path=cfg.metric_cache_path,
             force_feature_computation=cfg.force_feature_computation,
             proposal_sampling=instantiate(cfg.proposal_sampling),
+            pdm_search_depth_backward=cfg.pdm_search_depth_backward,
+            pdm_search_depth_forward=cfg.pdm_search_depth_forward,
         )
 
         logger.info(f"Extracted {len(scene_loader)} scenarios for thread_id={thread_id}, node_id={node_id}.")

--- a/navsim/planning/metric_caching/metric_cache_processor.py
+++ b/navsim/planning/metric_caching/metric_cache_processor.py
@@ -38,14 +38,20 @@ class MetricCacheProcessor:
         cache_path: Optional[str],
         force_feature_computation: bool,
         proposal_sampling: TrajectorySampling,
+        pdm_search_depth_backward: int = 15,
+        pdm_search_depth_forward: int = 30,
     ):
         """
         Initialize class.
         :param cache_path: Whether to cache features.
         :param force_feature_computation: If true, even if cache exists, it will be overwritten.
+        :param pdm_search_depth_backward: depth of backward BFS search for route correction
+        :param pdm_search_depth_forward: depth of forward BFS search for route correction
         """
         self._cache_path = pathlib.Path(cache_path) if cache_path else None
         self._force_feature_computation = force_feature_computation
+        self._pdm_search_depth_backward = pdm_search_depth_backward
+        self._pdm_search_depth_forward = pdm_search_depth_forward
 
         # 1s additional observation for ttc metric
         future_poses = proposal_sampling.num_poses + int(1.0 / proposal_sampling.interval_length)
@@ -66,6 +72,8 @@ class MetricCacheProcessor:
             ),
             lateral_offsets=[-1.0, 1.0],
             map_radius=self._map_radius,
+            pdm_search_depth_backward=self._pdm_search_depth_backward,
+            pdm_search_depth_forward=self._pdm_search_depth_forward,
         )
 
     def _get_planner_inputs(self, scenario: AbstractScenario) -> Tuple[PlannerInput, PlannerInitialization]:

--- a/navsim/planning/script/config/metric_caching/default_metric_caching.yaml
+++ b/navsim/planning/script/config/metric_caching/default_metric_caching.yaml
@@ -14,4 +14,8 @@ defaults:
 
 force_feature_computation: True
 
+# PDM Planner Route Correction Parameters
+pdm_search_depth_backward: 15
+pdm_search_depth_forward: 30
+
 output_dir: ${metric_cache_path}/metadata

--- a/navsim/planning/simulation/planner/pdm_planner/abstract_pdm_closed_planner.py
+++ b/navsim/planning/simulation/planner/pdm_planner/abstract_pdm_closed_planner.py
@@ -31,6 +31,8 @@ class AbstractPDMClosedPlanner(AbstractPDMPlanner):
         idm_policies: BatchIDMPolicy,
         lateral_offsets: Optional[List[float]],
         map_radius: float,
+        pdm_search_depth_backward: int = 15,
+        pdm_search_depth_forward: int = 30,
     ):
         """
         Constructor for AbstractPDMClosedPlanner
@@ -39,9 +41,15 @@ class AbstractPDMClosedPlanner(AbstractPDMPlanner):
         :param idm_policies: BatchIDMPolicy class
         :param lateral_offsets: centerline offsets for proposals (optional)
         :param map_radius: radius around ego to consider
+        :param pdm_search_depth_backward: depth of backward BFS search for route correction
+        :param pdm_search_depth_forward: depth of forward BFS search for route correction
         """
 
-        super(AbstractPDMClosedPlanner, self).__init__(map_radius)
+        super(AbstractPDMClosedPlanner, self).__init__(
+            map_radius,
+            pdm_search_depth_backward=pdm_search_depth_backward,
+            pdm_search_depth_forward=pdm_search_depth_forward,
+        )
 
         assert (
             trajectory_sampling.interval_length == proposal_sampling.interval_length

--- a/navsim/planning/simulation/planner/pdm_planner/abstract_pdm_planner.py
+++ b/navsim/planning/simulation/planner/pdm_planner/abstract_pdm_planner.py
@@ -26,13 +26,19 @@ class AbstractPDMPlanner(AbstractPlanner, ABC):
     def __init__(
         self,
         map_radius: float,
+        pdm_search_depth_backward: int = 15,
+        pdm_search_depth_forward: int = 30,
     ):
         """
         Constructor of AbstractPDMPlanner.
         :param map_radius: radius around ego to consider
+        :param pdm_search_depth_backward: depth of backward BFS search for route correction
+        :param pdm_search_depth_forward: depth of forward BFS search for route correction
         """
 
         self._map_radius: int = map_radius  # [m]
+        self._pdm_search_depth_backward = pdm_search_depth_backward
+        self._pdm_search_depth_forward = pdm_search_depth_forward
         self._iteration: int = 0
 
         # lazy loaded
@@ -68,7 +74,13 @@ class AbstractPDMPlanner(AbstractPlanner, ABC):
         Corrects the roadblock route and reloads lane-graph dictionaries.
         :param ego_state: state of the ego vehicle.
         """
-        route_roadblock_ids = route_roadblock_correction(ego_state.rear_axle, self._map_api, self._route_roadblock_dict)
+        route_roadblock_ids = route_roadblock_correction(
+            ego_state.rear_axle,
+            self._map_api,
+            self._route_roadblock_dict,
+            search_depth_backward=self._pdm_search_depth_backward,
+            search_depth_forward=self._pdm_search_depth_forward,
+        )
         self._load_route_dicts(route_roadblock_ids)
 
     def _get_discrete_centerline(self, current_lane: LaneGraphEdgeMapObject, search_depth: int = 30) -> List[StateSE2]:

--- a/navsim/planning/simulation/planner/pdm_planner/pdm_closed_planner.py
+++ b/navsim/planning/simulation/planner/pdm_planner/pdm_closed_planner.py
@@ -30,6 +30,8 @@ class PDMClosedPlanner(AbstractPDMClosedPlanner):
         idm_policies: BatchIDMPolicy,
         lateral_offsets: Optional[List[float]],
         map_radius: float,
+        pdm_search_depth_backward: int = 15,
+        pdm_search_depth_forward: int = 30,
     ):
         """
         Constructor for PDMClosedPlanner
@@ -38,6 +40,8 @@ class PDMClosedPlanner(AbstractPDMClosedPlanner):
         :param idm_policies: BatchIDMPolicy class
         :param lateral_offsets: centerline offsets for proposals (optional)
         :param map_radius: radius around ego to consider
+        :param pdm_search_depth_backward: depth of backward BFS search for route correction
+        :param pdm_search_depth_forward: depth of forward BFS search for route correction
         """
         super(PDMClosedPlanner, self).__init__(
             trajectory_sampling,
@@ -45,6 +49,8 @@ class PDMClosedPlanner(AbstractPDMClosedPlanner):
             idm_policies,
             lateral_offsets,
             map_radius,
+            pdm_search_depth_backward,
+            pdm_search_depth_forward,
         )
 
     def initialize(self, initialization: PlannerInitialization) -> None:


### PR DESCRIPTION
### Summary
Addressed an issue where `route_roadblock_correction` would hang or take an excessive amount of time due to BFS search on certain maps.
This PR makes the search depth limits (`search_depth_backward`, `search_depth_forward`) configurable via Hydra config, allowing users to reduce the search space and avoid infinite loops.

### Changes
1.  **Configuration**: Added `pdm_search_depth_backward` and `pdm_search_depth_forward` to `default_metric_caching.yaml` (defaults kept at 15 and 30).
2.  **Parameter Propagation**: Updated constructors and method calls in `MetricCacheProcessor`, `PDMClosedPlanner`, `AbstractPDMClosedPlanner`, and `AbstractPDMPlanner` to propagate these parameters down to `route_utils`.
3.  **Bug Fix**: Fixed a bug in `AbstractPDMClosedPlanner` where arguments were not passed to `super().__init__`.

### Impact
*   PDM Planner related classes in `navsim/planning`.
*   Metric caching execution flow.
*   No behavioral change if default values are used. Lower values can prevent hang-ups and reduce computation time.
