### PR TITLE
Fix UnboundLocalError for all_mappings in run_pdm_score.py

### DIFF
--- a/navsim/planning/script/run_pdm_score.py
+++ b/navsim/planning/script/run_pdm_score.py
@@ -383,6 +383,7 @@ def main(cfg: DictConfig) -> None:
         traceback.print_exc()
         pdm_score_df["weight"] = 1.0
         pseudo_closed_loop_valid = False
+        all_mappings = {}
 
     num_sucessful_scenarios = pdm_score_df["valid"].sum()
     num_failed_scenarios = len(pdm_score_df) - num_sucessful_scenarios


### PR DESCRIPTION
## Summary

- Fixes `UnboundLocalError: local variable 'all_mappings' referenced before assignment` in `run_pdm_score.py`
- When `reactive_all_mapping` config key is missing, the `except` block now initializes `all_mappings = {}` so downstream code (`calculate_individual_mapping_scores`) doesn't crash

Fixes #182

## Changes

In `navsim/planning/script/run_pdm_score.py`, added `all_mappings = {}` to the `except` block (line 386) that handles the missing `reactive_all_mapping` configuration key. Previously, `all_mappings` was only assigned inside the `try` block, causing an `UnboundLocalError` when the exception path was taken.

## Test plan

- Run `run_pdm_score.py` with a split that lacks `reactive_all_mapping` (e.g., `navtest_two_stage`) and confirm it completes without crashing